### PR TITLE
Testing demo for search functionality

### DIFF
--- a/src/containers/dashboard.ts
+++ b/src/containers/dashboard.ts
@@ -50,6 +50,9 @@ export class DashboardElement extends ConnectedElement {
   // ------------------------------------------
   // SAMPLE CODE FOR PRANSHU --- TO BE REMOVED
   @internalProperty()
+  searchResults: string[] = [];
+
+  @internalProperty()
   blogFeedIds: string[] = [];
 
   @internalProperty()
@@ -57,6 +60,9 @@ export class DashboardElement extends ConnectedElement {
 
   @query('#user-id-input')
   userIdElement: UprtclTextField;
+
+  @query('#levels')
+  levels: any;
   // ------------------------------------------
 
   dashboardPerspective: Secured<Perspective>;
@@ -105,6 +111,12 @@ export class DashboardElement extends ConnectedElement {
   async getUserBlogId() {
     const el = this.userIdElement;
     this.userBlogId = await this.appManager.getBlogIdOf(el.value);
+  }
+
+  async searchBlog() {
+    const userId = localStorage.getItem('AUTH0_USER_ID');
+    const el = this.userIdElement;
+    this.searchResults = await this.appManager.blogFeedSearch(userId, el.value, this.levels.checked);
   }
   // ------------------------------------------
 
@@ -263,14 +275,26 @@ export class DashboardElement extends ConnectedElement {
       <!-- --------------------------------------- -->
       <!-- SAMPLE CODE FOR PRANSHI TO BE REMOVED -->
       <hr />
-      <uprtcl-textfield id="user-id-input" label="userid"></uprtcl-textfield>
-      <uprtcl-button @click=${() => this.getUserBlogId()}>get</uprtcl-button>
+      <uprtcl-textfield id="user-id-input" label="userid or search text"></uprtcl-textfield>
+      <uprtcl-button @click=${() => this.searchBlog()}>search</uprtcl-button>'
+      <div>
+        <input type="checkbox" id="levels" name="levels"/>
+        <label for="levels">Level -1</label>
+      </div>
+      <uprtcl-button @click=${() => this.getUserBlogId()}>get user</uprtcl-button>
       <span>${this.userBlogId ? this.userBlogId : 'undefined'}</span>
 
       <hr />
       <b>feed</b>
       <uprtcl-list
         >${this.blogFeedIds.map(
+          (id) => html`<uprtcl-list-item>${id}</uprtcl-list-item>`
+        )}</uprtcl-list
+      >
+      <hr />
+      <b>Search results</b>
+      <uprtcl-list
+        >${this.searchResults.map(
           (id) => html`<uprtcl-list-item>${id}</uprtcl-list-item>`
         )}</uprtcl-list
       >
@@ -335,6 +359,7 @@ export class DashboardElement extends ConnectedElement {
         }
 
         .app-navbar {
+          overflow-y: auto; /* Hardcoded for testing only!!! */
           scrollbar-width: 0; /* Firefox */
           width: 250px;
           flex-shrink: 0;

--- a/src/services/app.manager.ts
+++ b/src/services/app.manager.ts
@@ -128,6 +128,23 @@ export class AppManager {
     return result.perspectiveIds;
   }
 
+  // Use it to explore by text under a userHome linked to his blogHomeConcept.
+  async blogFeedSearch(userId: string, textInput: string, levels: boolean): Promise<any> {
+    const userHome = await getHome(this.evees.getRemote(), userId);
+    const blogHomeConcept = await this.getConcept(ConceptId.BLOGPOST);
+
+    const result = await this.evees.client.searchEngine.explore({
+      under: [{ id: userHome.id }],
+      linksTo: [{ id: blogHomeConcept.id }],
+      text: {
+        value: textInput,
+        levels: levels ? -1 : 0
+      }
+    });
+
+    return result.perspectiveIds;
+  }
+
   // TODO: TEST: find another user's blogs to simulate follows
   async getBlogIdOf(userId: string): Promise<string | undefined> {
     const userHome = await getHome(this.evees.getRemote(), userId);


### PR DESCRIPTION
I added a `blogSearchFeed` function that will allow searching by text and any means. Besides, I added some UI to be able to play with the server and have some views of the current state of the functionality.

To test the search functionality one must use the `Search` button and use the same text input for `userId`, then click on the `Search` button instead of clicking on the `Get User` button.

Also, a check input is provided to specify the levels of searching which means:

1. Minus one (-1) to search along for both post's titles and text inside the post's bodies.
2. Zero (0) to search only throughout the post's titles.

![Search button demo](https://user-images.githubusercontent.com/16869766/109737122-819ea980-7b93-11eb-8a30-ee1e97e52db4.png)

Search results are as well displayed below. An `overflow-y: auto` was added to enable scrolling down in the `nav-app` and be able to see the search results.

![search results](https://user-images.githubusercontent.com/16869766/109737206-a4c95900-7b93-11eb-8020-8e3c5c62f2b3.png)
